### PR TITLE
introduce coveralls service to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,11 @@ install:
 script:
   - tox
 
+after_success:
+  # Send coverage to coveralls:
+  - pip install coverage coveralls
+  - coverage combine .tests_reports/
+  - coveralls --rcfile=setup.cfg
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Django Test Migrations
 
 [![Build Status](https://travis-ci.org/skarzi/django-test-migrations.svg?branch=master)](https://travis-ci.org/skarzi/django-test-migrations)
+[![Coverage Status](https://coveralls.io/repos/github/skarzi/django-test-migrations/badge.svg)](https://coveralls.io/github/skarzi/django-test-migrations)
 
 Django migration testing utilities
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,10 @@ usedevelop = true
 changedir = 
     integration_unittest: tests/integration/testing_project
     integration_pytest: tests/integration/testing_project
+setenv=
+    # `[coverage:run] data_file` option is overriden here to make
+    # combining coverage's results possible
+    {unit,pytest_plugin}: COVERAGE_FILE=.tests_reports/.coverage.{envname}
 extras =
     integration_pytest: pytest
     pytest_plugin: pytest


### PR DESCRIPTION
Improve code coverage computing - pytest's plugin tests require
different setup of pytest than regular unit tests, so they have to be
ran in separate tox's envs, which require combining of coverage's results.